### PR TITLE
Cleans up home and events pages

### DIFF
--- a/src/pages/events.js
+++ b/src/pages/events.js
@@ -57,7 +57,16 @@ const IndexPage = () => {
         </section>
 
         <section css={contentStyles}>
-          <p>Add some event info...</p>
+          <h3>December 2018</h3>
+          <h4>ReactJS @ BottleRocket</h4>
+          <div>6:15 - 7:00pm: Pizza/Drinks & meeting other people</div>
+          <div>6:30 - 7:00pm: Jobs Open Mic and jobs follow-up</div>
+          <div>7:00 - 7:45pm - Morgan Dedmon - "WASM: What is that?"</div>
+          <div>8:00 - 8:45pm: Salvador Aceves - "Redux Sagas in Practice"</div>
+
+          <p style={{ marginTop: 12 }}>
+            <a href="https://www.meetup.com/ReactJSDallas/events/pbbdwnyxqbpb/">Meetup link</a>
+          </p>
         </section>
 
         <div css={dallasLogoContainerStyles}>

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 // External Dependencies
 import React from 'react';
-import { Link } from 'gatsby';
+// import { Link } from 'gatsby';
 
 // Internal Dependencies
 import Layout from '../components/layout';
@@ -8,11 +8,15 @@ import DallasLogoSvg from '../images/reactjs-dallas-icon.svg';
 
 // Local Variables
 const rootStyles = {
+  display: 'flex',
+  flexDirection: 'column',
   textAlign: 'center'
 };
 
 const heroContainerStyles = {
   background: '#282C34',
+  display: 'flex',
+  justifyContent: 'center',
   padding: '2rem',
 };
 
@@ -27,8 +31,10 @@ const heroTextStyles = {
 
 const contentStyles = {
   display: 'flex',
+  flexGrow: 1,
   flexDirection: 'column',
   justifyContent: 'center',
+  minHeight: 310,
   padding: '3.5rem 0',
 }
 
@@ -57,10 +63,10 @@ const IndexPage = () => {
         </section>
 
         <section css={contentStyles}>
-          <p>Welcome to DFW!</p>
-          <p>Now go build something great.</p>
+          <p>Welcome to the DFW React Community!</p>
+          <p>Now go build something great</p>
           <p>And show someone else how to do it, too! 🤓</p>
-          <Link to="/signup/">Go to sign up</Link>
+          {/* <Link to="/signup/">Go to sign up</Link> */}
         </section>
 
         <div css={dallasLogoContainerStyles}>


### PR DESCRIPTION
Updating content to be presentable to the public.

- Home page updated with more generic info
  - Removed the "sign up" link
- Events page updated with the December 2018 meetup details

Page | Before | After
--------- | --------- | ---------
Home | ![image](https://user-images.githubusercontent.com/11624407/49825719-b8860c00-fd4a-11e8-8845-a48977d616aa.png) | ![image](https://user-images.githubusercontent.com/11624407/49825748-c8055500-fd4a-11e8-8141-ce7e1be64f1e.png)
Events | ![image](https://user-images.githubusercontent.com/11624407/49825771-d81d3480-fd4a-11e8-90e4-8f51c1617bac.png) | ![image](https://user-images.githubusercontent.com/11624407/49825783-e0756f80-fd4a-11e8-99b6-0bdb72151dc0.png)


