### PR TITLE
fix: update talk title, add day to date

### DIFF
--- a/src/utils/constants/events.js
+++ b/src/utils/constants/events.js
@@ -325,11 +325,11 @@ export const pastEventData = [
 export const futureEventData = [
   {
     imageBackgroundColor: null,
-    date: 'March 2021',
+    date: 'March 9, 2021',
     imageLink:
       'https://images.unsplash.com/photo-1588702547923-7093a6c3ba33?ixid=MXwxMjA3fDB8MHxwaG90by1wYWdlfHx8fGVufDB8fHw%3D&ixlib=rb-1.2.1&auto=format&fit=crop&w=1950&q=80',
     meetupLink: 'https://www.meetup.com/ReactJSDallas/events/mrkxmryccfbmb/',
-    speaker1: 'Justin Noel - TBD',
+    speaker1: 'Justin Noel - Flareact - Next.js Alternative for Cloudflare',
     venue: 'yourDevice',
   },
 ];


### PR DESCRIPTION
- Updates the talk title for March 2021
- Adds the day to the date for March 2021 (March 9, 2021) to let site visitors know exactly when the talk will be