### PR TITLE
updated the date in the footer to make it dynamic.

### DIFF
--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -21,6 +21,8 @@ const propTypes = {
     link: PropTypes.string.isRequired,
   }).isRequired,
 };
+const date = new Date();
+const year = date.getFullYear();
 
 const styles = theme => ({
   copyright: {
@@ -105,7 +107,7 @@ const Footer = ({
       </div>
     </div>
     <div className={classes.copyright}>
-      &copy; 2019 ReactJS Dallas User Group. All Rights Reserved.
+      &copy; {year} ReactJS Dallas User Group. All Rights Reserved.
     </div>
   </footer>
 );


### PR DESCRIPTION
Resolves issue https://github.com/reactjs-dallas/reactjs-dallas-site/issues/43 - Dynamically update year in footer 

Before|After
----|----
<img width="522" alt="Screen Shot 2021-04-01 at 8 43 43 AM" src="https://user-images.githubusercontent.com/24509848/113303178-7049d980-92c6-11eb-8d87-c8b59d032fd9.png">|<img width="522" alt="Screen Shot 2021-04-01 at 8 42 25 AM" src="https://user-images.githubusercontent.com/24509848/113303203-76d85100-92c6-11eb-99e7-5ad5f388c0b0.png">

