### PR TITLE
chore: require node v12

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.0",
   "author": "Mike Mathew <m2mathew@me.com>",
   "engines": {
-    "node": "^10.16.0",
+    "node": "^12",
     "npm": "6.x"
   },
   "repository": {


### PR DESCRIPTION
Require node `^12`