### PR TITLE
chore: update event details of April 2024

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "reactjs-dallas-site",
   "description": "Internet website for the ReactJS Dallas User Group",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "author": "Mike Mathew <m2mathew@me.com>",
   "engines": {
     "node": "^10.16.0",

--- a/src/components/footer.js
+++ b/src/components/footer.js
@@ -1,4 +1,6 @@
 // External Dependencies
+import Box from '@material-ui/core/Box';
+import Button from '@material-ui/core/Button';
 import PropTypes from 'prop-types';
 import React from 'react';
 import { withStyles } from '@material-ui/core/styles';
@@ -106,9 +108,19 @@ const Footer = ({
         </a>
       </div>
     </div>
+
     <div className={classes.copyright}>
       &copy; {year} ReactJS Dallas User Group. All Rights Reserved.
     </div>
+
+    <Box marginTop={2}>
+      <Button
+        color="primary"
+        href="/current-event"
+      >
+        View Current Event
+      </Button>
+    </Box>
   </footer>
 );
 

--- a/src/pages/current-event.js
+++ b/src/pages/current-event.js
@@ -11,7 +11,7 @@ const CurrentEvent = () => (
       <img
         alt="meetup-speaker"
         height="100%"
-        src="https://res.cloudinary.com/reactjs-dallas/image/upload/v1710254183/2024-03-12--reactjs_with_mark_mulligan_qxgybv.png"
+        src="https://res.cloudinary.com/reactjs-dallas/image/upload/v1712689786/2024-04-09--reactjs_dallas_with_mike_mathew_group_project_thkkla.png"
         width="100%"
       />
     </div>

--- a/src/utils/constants/events.js
+++ b/src/utils/constants/events.js
@@ -1,6 +1,16 @@
 export const eventData = [
   {
     imageBackgroundColor: null,
+    date: 'April 2024',
+    fullWidthImage: true,
+    imageLink:
+      'https://res.cloudinary.com/reactjs-dallas/image/upload/v1712689786/2024-04-09--reactjs_dallas_with_mike_mathew_group_project_thkkla.png',
+    meetupLink: 'https://www.meetup.com/reactjsdallas/events/298071586/',
+    speaker1: 'Group Project: Update the ReactJS Dallas Website',
+    venue: 'Text-Em-All',
+  },
+  {
+    imageBackgroundColor: null,
     date: 'March 2024',
     fullWidthImage: true,
     imageLink:


### PR DESCRIPTION
- Update April 2024 event details
- Add button in the footer that takes user to the `/current-details` page.

![2024-04-09--reactjs_dallas_with_mike_mathew_group_project](https://github.com/reactjs-dallas/reactjs-dallas-site/assets/11624407/07f12372-cb72-4c0f-8e74-7871cef6eb49)
